### PR TITLE
releases/v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## v2.1.0 (SNAPSHOT)
+
+### Added
+
+- Add `KtInventoryPluginContext` to simplify plugin dependency injection.
+  - Replaced direct `Plugin` injection with `KtInventoryPluginContext`, which packages plugin-dependent data.
+  - This simplifies constructor dependencies and makes testing or future dependency swapping easier.
+  - Existing `Plugin` constructors are now `@Deprecated` and delegate to `KtInventoryPluginContext(plugin)`.
+    ```kotlin
+    // Before
+    class SimpleMenu(
+        plugin: Plugin,
+    ) : KtInventory(plugin, 1)
+
+    // After
+    class SimpleMenu(
+        context: KtInventoryPluginContext,
+    ) : KtInventory(context, 1) {
+        constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
+    }
+    ```
+
+## v2.0.0
+
+Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.1.0 (SNAPSHOT)
+## v2.1.0
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ dependencies {
 
 ```kotlin
 class SimpleMenu(
-    plugin: Plugin,
-) : KtInventory(plugin, 1) {
+    context: KtInventoryPluginContext,
+) : KtInventory(context, 1) {
+    constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
+
     override fun title() = "&0&lSelect where to teleport"
 
     init {
@@ -56,8 +58,10 @@ class SimpleMenu(
 
 ```kotlin
 class SimpleMenu(
-    plugin: Plugin,
-) : KtInventoryAdventure(plugin, 1) {
+    context: KtInventoryPluginContext,
+) : KtInventoryAdventure(context, 1) {
+    constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
+
     override fun title() = Component.text("Select where to teleport").color(NamedTextColor.BLACK).decorate(TextDecoration.BOLD)
 
     init {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ktInventory
 
-[![Kotlin](https://img.shields.io/badge/kotlin-2.1.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![GitHub License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/dev.s7a/ktInventory)](https://search.maven.org/artifact/dev.s7a/ktInventory)
 [![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://gh.s7a.dev/ktInventory)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Spigot library with Kotlin for easy inventory creation and event handling
 
 ```kotlin
 repositories {
-    maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
+    mavenCentral()
 }
 
 dependencies {
-    implementation("dev.s7a:ktInventory:2.1.0-SNAPSHOT")
+    implementation("dev.s7a:ktInventory:2.1.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation("dev.s7a:ktInventory:2.0.0-SNAPSHOT")
+    implementation("dev.s7a:ktInventory:2.1.0-SNAPSHOT")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "dev.s7a"
-version = "2.0.0"
+version = "2.1.0-SNAPSHOT"
 
 allprojects {
     apply(plugin = "kotlin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "dev.s7a"
-version = "2.1.0-SNAPSHOT"
+version = "2.1.0"
 
 allprojects {
     apply(plugin = "kotlin")

--- a/example/src/main/kotlin/dev/s7a/ktinventory/example/ExamplePlugin.kt
+++ b/example/src/main/kotlin/dev/s7a/ktinventory/example/ExamplePlugin.kt
@@ -25,22 +25,27 @@ class ExamplePlugin : JavaPlugin() {
                     SimpleMenu(this).open(sender)
                     return true
                 }
+
                 "paper-menu" -> {
                     SimpleMenuPaper(this).open(sender)
                     return true
                 }
+
                 "settings" -> {
                     SettingsInventory(this).open(sender)
                     return true
                 }
+
                 "sound" -> {
                     SoundCheckInventory(this).open(sender)
                     return true
                 }
+
                 "sound-paper" -> {
                     SoundCheckInventoryPaper(this).open(sender)
                     return true
                 }
+
                 "storage" -> {
                     StorageInventory(this).open(sender)
                     return true

--- a/example/src/main/kotlin/dev/s7a/ktinventory/example/menu/SimpleMenu.kt
+++ b/example/src/main/kotlin/dev/s7a/ktinventory/example/menu/SimpleMenu.kt
@@ -1,14 +1,17 @@
 package dev.s7a.ktinventory.example.menu
 
 import dev.s7a.ktinventory.KtInventory
+import dev.s7a.ktinventory.KtInventoryPluginContext
 import dev.s7a.ktinventory.example.itemStack
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
 
 class SimpleMenu(
-    plugin: Plugin,
-) : KtInventory(plugin, 1) {
+    context: KtInventoryPluginContext,
+) : KtInventory(context, 1) {
+    constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
+
     override fun title() = "&0&lSelect where to teleport"
 
     init {

--- a/example/src/main/kotlin/dev/s7a/ktinventory/example/paper/menu/SimpleMenuPaper.kt
+++ b/example/src/main/kotlin/dev/s7a/ktinventory/example/paper/menu/SimpleMenuPaper.kt
@@ -1,6 +1,7 @@
 package dev.s7a.ktinventory.example.paper.menu
 
 import dev.s7a.ktinventory.KtInventoryAdventure
+import dev.s7a.ktinventory.KtInventoryPluginContext
 import dev.s7a.ktinventory.example.itemStack
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -10,8 +11,10 @@ import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
 
 class SimpleMenuPaper(
-    plugin: Plugin,
-) : KtInventoryAdventure(plugin, 1) {
+    context: KtInventoryPluginContext,
+) : KtInventoryAdventure(context, 1) {
+    constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
+
     override fun title() = Component.text("Select where to teleport").color(NamedTextColor.BLACK).decorate(TextDecoration.BOLD)
 
     init {

--- a/example/src/main/kotlin/dev/s7a/ktinventory/example/paper/soundchecker/SoundCheckInventoryPaper.kt
+++ b/example/src/main/kotlin/dev/s7a/ktinventory/example/paper/soundchecker/SoundCheckInventoryPaper.kt
@@ -1,6 +1,7 @@
 package dev.s7a.ktinventory.example.paper.soundchecker
 
 import dev.s7a.ktinventory.KtInventoryPaginatedAdventure
+import dev.s7a.ktinventory.KtInventoryPluginContext
 import dev.s7a.ktinventory.example.itemStack
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -11,8 +12,10 @@ import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
 
 class SoundCheckInventoryPaper(
-    plugin: Plugin,
-) : KtInventoryPaginatedAdventure(plugin, 6) {
+    context: KtInventoryPluginContext,
+) : KtInventoryPaginatedAdventure(context, 6) {
+    constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
+
     override val entries =
         Registry.SOUNDS.map { sound ->
             createButton(

--- a/example/src/main/kotlin/dev/s7a/ktinventory/example/settings/SettingsInventory.kt
+++ b/example/src/main/kotlin/dev/s7a/ktinventory/example/settings/SettingsInventory.kt
@@ -1,14 +1,17 @@
 package dev.s7a.ktinventory.example.settings
 
 import dev.s7a.ktinventory.KtInventory
+import dev.s7a.ktinventory.KtInventoryPluginContext
 import dev.s7a.ktinventory.example.itemStack
 import org.bukkit.Material
 import org.bukkit.entity.HumanEntity
 import org.bukkit.plugin.Plugin
 
 class SettingsInventory(
-    val plugin: Plugin,
-) : KtInventory(plugin, 1) {
+    val context: KtInventoryPluginContext,
+) : KtInventory(context, 1) {
+    constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
+
     override fun title() = "&0&lSettings"
 
     init {
@@ -28,6 +31,6 @@ class SettingsInventory(
         override fun createNew(
             player: HumanEntity,
             inventory: SettingsInventory,
-        ) = SettingsInventory(inventory.plugin)
+        ) = SettingsInventory(inventory.context)
     }
 }

--- a/example/src/main/kotlin/dev/s7a/ktinventory/example/soundchecker/SoundCheckInventory.kt
+++ b/example/src/main/kotlin/dev/s7a/ktinventory/example/soundchecker/SoundCheckInventory.kt
@@ -1,6 +1,7 @@
 package dev.s7a.ktinventory.example.soundchecker
 
 import dev.s7a.ktinventory.KtInventoryPaginated
+import dev.s7a.ktinventory.KtInventoryPluginContext
 import dev.s7a.ktinventory.example.itemStack
 import org.bukkit.Material
 import org.bukkit.Registry
@@ -8,8 +9,10 @@ import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
 
 class SoundCheckInventory(
-    plugin: Plugin,
-) : KtInventoryPaginated(plugin, 6) {
+    context: KtInventoryPluginContext,
+) : KtInventoryPaginated(context, 6) {
+    constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
+
     override val entries =
         Registry.SOUNDS.map { sound ->
             createButton(

--- a/example/src/main/kotlin/dev/s7a/ktinventory/example/storage/StorageInventory.kt
+++ b/example/src/main/kotlin/dev/s7a/ktinventory/example/storage/StorageInventory.kt
@@ -1,13 +1,14 @@
 package dev.s7a.ktinventory.example.storage
 
 import dev.s7a.ktinventory.KtInventory
+import dev.s7a.ktinventory.KtInventoryPluginContext
 import org.bukkit.Bukkit
 import org.bukkit.inventory.ItemStack
 import org.bukkit.plugin.Plugin
 
 class StorageInventory(
     plugin: Plugin,
-) : KtInventory(plugin, 6) {
+) : KtInventory(KtInventoryPluginContext(plugin), 6) {
     override fun title() = "&0&lStorage"
 
     init {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 # Plugins
-kotlin = "2.1.10"
+kotlin = "2.3.10"
 dokka = "2.1.0"
-kotlinter = "5.0.1"
+kotlinter = "5.4.2"
 pluginYml = "0.6.0"
-minecraftServer = "3.2.1"
+minecraftServer = "4.0.2"
 shadow = "8.1.1"
 mavenPublish = "0.35.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/dev/s7a/ktinventory/AbstractKtInventory.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/AbstractKtInventory.kt
@@ -9,7 +9,6 @@ import org.bukkit.entity.HumanEntity
 import org.bukkit.entity.Player
 import org.bukkit.inventory.InventoryHolder
 import org.bukkit.inventory.ItemStack
-import org.bukkit.plugin.Plugin
 import kotlin.reflect.KClass
 
 /**
@@ -19,7 +18,7 @@ import kotlin.reflect.KClass
  * @since 2.0.0
  */
 abstract class AbstractKtInventory(
-    private val plugin: Plugin,
+    private val context: KtInventoryPluginContext,
     line: Int,
 ) : KtInventoryBase(line),
     InventoryHolder {
@@ -74,7 +73,7 @@ abstract class AbstractKtInventory(
     }
 
     final override fun open(player: HumanEntity) {
-        KtInventoryHandler.register(plugin)
+        KtInventoryHandler.register(context)
         player.openInventory(inventory)
     }
 

--- a/src/main/kotlin/dev/s7a/ktinventory/AbstractKtInventoryPaginated.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/AbstractKtInventoryPaginated.kt
@@ -17,14 +17,22 @@ import kotlin.reflect.KClass
  * Base class for paginated inventories
  *
  * @param T Type of the paginated inventory
- * @param plugin Plugin instance
+ * @param context Plugin context
  * @param line Number of inventory rows
- * @since 2.0.0
+ * @since 2.1.0
  */
 abstract class AbstractKtInventoryPaginated<T : AbstractKtInventoryPaginated<T>>(
-    private val plugin: Plugin,
+    private val context: KtInventoryPluginContext,
     line: Int,
 ) : KtInventoryBase(line) {
+    /**
+     * @param plugin Plugin instance
+     * @param line Number of inventory rows
+     * @since 2.0.0
+     */
+    @Deprecated("Use KtInventoryPluginContext constructor instead")
+    constructor(plugin: Plugin, line: Int) : this(KtInventoryPluginContext(plugin), line)
+
     /**
      * List of slot numbers used for pagination
      *
@@ -233,7 +241,7 @@ abstract class AbstractKtInventoryPaginated<T : AbstractKtInventoryPaginated<T>>
         val paginated: T,
         val page: Int,
         val lastPage: Int,
-    ) : AbstractKtInventory(paginated.plugin, paginated.line) {
+    ) : AbstractKtInventory(paginated.context, paginated.line) {
         /**
          * Opens next page for a player
          *

--- a/src/main/kotlin/dev/s7a/ktinventory/KtInventory.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/KtInventory.kt
@@ -1,22 +1,36 @@
 package dev.s7a.ktinventory
 
 import net.md_5.bungee.api.ChatColor
+import org.bukkit.Bukkit
 import org.bukkit.plugin.Plugin
 
 /**
  * Abstract inventory class that creates an inventory with a customizable title.
  * Extends [AbstractKtInventory] to provide basic inventory functionality.
  *
- * @param plugin The plugin instance
+ * @param context Plugin context
  * @param line Number of inventory rows
  * @param altColorChar Character used for color codes in the title. Default is '&'. Set to null to disable color code translation.
- * @since 2.0.0
+ * @since 2.1.0
  */
 abstract class KtInventory(
-    plugin: Plugin,
+    context: KtInventoryPluginContext,
     line: Int,
     altColorChar: Char? = '&',
-) : AbstractKtInventory(plugin, line) {
+) : AbstractKtInventory(context, line) {
+    /**
+     * @param plugin The plugin instance
+     * @param line Number of inventory rows
+     * @param altColorChar Character used for color codes in the title. Default is '&'. Set to null to disable color code translation.
+     * @since 2.0.0
+     */
+    @Deprecated("Use KtInventoryPluginContext constructor instead")
+    constructor(plugin: Plugin, line: Int, altColorChar: Char? = '&') : this(
+        KtInventoryPluginContext(plugin),
+        line,
+        altColorChar,
+    )
+
     /**
      * Gets the title of the inventory.
      * The title can include color codes if [altColorChar] is not null.
@@ -28,7 +42,8 @@ abstract class KtInventory(
 
     @Suppress("DEPRECATION")
     private val _inventory by lazy {
-        plugin.server.createInventory(
+        @Suppress("DEPRECATION")
+        Bukkit.createInventory(
             this,
             size,
             if (altColorChar != null) ChatColor.translateAlternateColorCodes(altColorChar, title()) else title(),

--- a/src/main/kotlin/dev/s7a/ktinventory/KtInventoryAdventure.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/KtInventoryAdventure.kt
@@ -1,19 +1,31 @@
 package dev.s7a.ktinventory
 
 import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
 import org.bukkit.plugin.Plugin
 
 /**
  * An abstract inventory implementation that uses Adventure's Component for titles.
  *
- * @param plugin The plugin instance
+ * @param context Plugin context
  * @param line Number of inventory rows
- * @since 2.0.0
+ * @since 2.1.0
  */
 abstract class KtInventoryAdventure(
-    plugin: Plugin,
+    context: KtInventoryPluginContext,
     line: Int,
-) : AbstractKtInventory(plugin, line) {
+) : AbstractKtInventory(context, line) {
+    /**
+     * @param plugin The plugin instance
+     * @param line Number of inventory rows
+     * @since 2.0.0
+     */
+    @Deprecated("Use KtInventoryPluginContext constructor instead")
+    constructor(plugin: Plugin, line: Int) : this(
+        KtInventoryPluginContext(plugin),
+        line,
+    )
+
     /**
      * Returns the title of this inventory as a Component.
      *
@@ -23,7 +35,7 @@ abstract class KtInventoryAdventure(
     abstract fun title(): Component
 
     private val _inventory by lazy {
-        plugin.server.createInventory(this, size, title())
+        Bukkit.createInventory(this, size, title())
     }
 
     override fun getInventory() = _inventory

--- a/src/main/kotlin/dev/s7a/ktinventory/KtInventoryHandler.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/KtInventoryHandler.kt
@@ -9,16 +9,15 @@ import org.bukkit.event.inventory.InventoryCloseEvent
 import org.bukkit.event.inventory.InventoryDragEvent
 import org.bukkit.event.inventory.InventoryOpenEvent
 import org.bukkit.event.server.PluginDisableEvent
-import org.bukkit.plugin.Plugin
 
 /**
  * Internal handler for KtInventory events.
  *
- * @property plugin The plugin instance
+ * @property context Plugin context
  * @since 2.0.0
  */
 internal class KtInventoryHandler(
-    private val plugin: Plugin,
+    private val context: KtInventoryPluginContext,
 ) : Listener {
     @EventHandler
     fun on(event: InventoryOpenEvent) {
@@ -88,24 +87,24 @@ internal class KtInventoryHandler(
 
     @EventHandler
     fun on(event: PluginDisableEvent) {
-        if (plugin === event.plugin) {
+        if (context === event.plugin) {
             Bukkit.getOnlinePlayers().forEach { player ->
                 val inventory = player.openInventory.topInventory
                 if (inventory.holder !is AbstractKtInventory) return@forEach
                 player.closeInventory()
             }
-            handlers.remove(plugin)
+            handlers.remove(context)
         }
     }
 
     companion object {
-        private val handlers = mutableMapOf<Plugin, KtInventoryHandler>()
+        private val handlers = mutableMapOf<KtInventoryPluginContext, KtInventoryHandler>()
 
         @Synchronized
-        fun register(plugin: Plugin) =
-            handlers.getOrPut(plugin) {
-                KtInventoryHandler(plugin).apply {
-                    plugin.server.pluginManager.registerEvents(this, plugin)
+        fun register(context: KtInventoryPluginContext) =
+            handlers.getOrPut(context) {
+                KtInventoryHandler(context).apply {
+                    context.registerEvents(this)
                 }
             }
     }

--- a/src/main/kotlin/dev/s7a/ktinventory/KtInventoryPaginated.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/KtInventoryPaginated.kt
@@ -1,6 +1,7 @@
 package dev.s7a.ktinventory
 
 import net.md_5.bungee.api.ChatColor
+import org.bukkit.Bukkit
 import org.bukkit.entity.HumanEntity
 import org.bukkit.plugin.Plugin
 import kotlin.reflect.KClass
@@ -8,16 +9,29 @@ import kotlin.reflect.KClass
 /**
  * Abstract class for paginated inventories with customizable titles.
  *
- * @param plugin The plugin instance
+ * @param context Plugin context
  * @param line Number of inventory lines (1-6)
  * @param altColorChar The alternate color code character for title color formatting, defaults to '&'
- * @since 2.0.0
+ * @since 2.1.0
  */
 abstract class KtInventoryPaginated(
-    private val plugin: Plugin,
+    private val context: KtInventoryPluginContext,
     line: Int,
     private val altColorChar: Char? = '&',
-) : AbstractKtInventoryPaginated<KtInventoryPaginated>(plugin, line) {
+) : AbstractKtInventoryPaginated<KtInventoryPaginated>(context, line) {
+    /**
+     * @param plugin The plugin instance
+     * @param line Number of inventory lines (1-6)
+     * @param altColorChar The alternate color code character for title color formatting, defaults to '&'
+     * @since 2.0.0
+     */
+    @Deprecated("Use KtInventoryPluginContext constructor instead")
+    constructor(plugin: Plugin, line: Int, altColorChar: Char? = '&') : this(
+        KtInventoryPluginContext(plugin),
+        line,
+        altColorChar,
+    )
+
     /**
      * Generates the title for a specific page of the inventory.
      *
@@ -52,7 +66,8 @@ abstract class KtInventoryPaginated(
     ) : AbstractKtInventoryPaginated.Entry<T>(paginated, page, lastPage) {
         @Suppress("DEPRECATION")
         private val _inventory by lazy {
-            paginated.plugin.server.createInventory(
+            @Suppress("DEPRECATION")
+            Bukkit.createInventory(
                 this,
                 size,
                 if (paginated.altColorChar != null) {

--- a/src/main/kotlin/dev/s7a/ktinventory/KtInventoryPaginatedAdventure.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/KtInventoryPaginatedAdventure.kt
@@ -1,6 +1,7 @@
 package dev.s7a.ktinventory
 
 import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
 import org.bukkit.entity.HumanEntity
 import org.bukkit.plugin.Plugin
 import kotlin.reflect.KClass
@@ -8,14 +9,25 @@ import kotlin.reflect.KClass
 /**
  * Abstract class for paginated inventories with Adventure Component titles.
  *
- * @param plugin The plugin instance
+ * @param context Plugin context
  * @param line Number of inventory lines (1-6)
- * @since 2.0.0
+ * @since 2.1.0
  */
 abstract class KtInventoryPaginatedAdventure(
-    private val plugin: Plugin,
+    context: KtInventoryPluginContext,
     line: Int,
-) : AbstractKtInventoryPaginated<KtInventoryPaginatedAdventure>(plugin, line) {
+) : AbstractKtInventoryPaginated<KtInventoryPaginatedAdventure>(context, line) {
+    /**
+     * @param plugin The plugin instance
+     * @param line Number of inventory lines (1-6)
+     * @since 2.0.0
+     */
+    @Deprecated("Use KtInventoryPluginContext constructor instead")
+    constructor(plugin: Plugin, line: Int) : this(
+        KtInventoryPluginContext(plugin),
+        line,
+    )
+
     /**
      * Generates the Component title for a specific page of the inventory.
      *
@@ -49,7 +61,7 @@ abstract class KtInventoryPaginatedAdventure(
         lastPage: Int,
     ) : AbstractKtInventoryPaginated.Entry<T>(paginated, page, lastPage) {
         private val _inventory by lazy {
-            paginated.plugin.server.createInventory(this, size, paginated.title(page, lastPage))
+            Bukkit.createInventory(this, size, paginated.title(page, lastPage))
         }
 
         override fun getInventory() = _inventory

--- a/src/main/kotlin/dev/s7a/ktinventory/KtInventoryPluginContext.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/KtInventoryPluginContext.kt
@@ -4,19 +4,6 @@ import org.bukkit.event.Listener
 import org.bukkit.plugin.Plugin
 
 /**
- * Creates a [KtInventoryPluginContext] instance for the specified [plugin].
- *
- * @since 2.1.0
- */
-@Suppress("FunctionName")
-fun KtInventoryPluginContext(plugin: Plugin) =
-    object : KtInventoryPluginContext {
-        override fun registerEvents(listener: Listener) {
-            plugin.server.pluginManager.registerEvents(listener, plugin)
-        }
-    }
-
-/**
  * Context interface for KtInventory plugin integration.
  *
  * This interface provides methods for registering event listeners within the plugin context.
@@ -31,4 +18,19 @@ interface KtInventoryPluginContext {
      * @since 2.1.0
      */
     fun registerEvents(listener: Listener)
+
+    companion object {
+        /**
+         * Creates a [KtInventoryPluginContext] instance for the specified [plugin].
+         *
+         * @since 2.1.0
+         */
+
+        operator fun invoke(plugin: Plugin) =
+            object : KtInventoryPluginContext {
+                override fun registerEvents(listener: Listener) {
+                    plugin.server.pluginManager.registerEvents(listener, plugin)
+                }
+            }
+    }
 }

--- a/src/main/kotlin/dev/s7a/ktinventory/KtInventoryPluginContext.kt
+++ b/src/main/kotlin/dev/s7a/ktinventory/KtInventoryPluginContext.kt
@@ -1,0 +1,34 @@
+package dev.s7a.ktinventory
+
+import org.bukkit.event.Listener
+import org.bukkit.plugin.Plugin
+
+/**
+ * Creates a [KtInventoryPluginContext] instance for the specified [plugin].
+ *
+ * @since 2.1.0
+ */
+@Suppress("FunctionName")
+fun KtInventoryPluginContext(plugin: Plugin) =
+    object : KtInventoryPluginContext {
+        override fun registerEvents(listener: Listener) {
+            plugin.server.pluginManager.registerEvents(listener, plugin)
+        }
+    }
+
+/**
+ * Context interface for KtInventory plugin integration.
+ *
+ * This interface provides methods for registering event listeners within the plugin context.
+ *
+ * @since 2.1.0
+ */
+interface KtInventoryPluginContext {
+    /**
+     * Registers an event listener with the plugin.
+     *
+     * @param listener The Bukkit event listener to be registered
+     * @since 2.1.0
+     */
+    fun registerEvents(listener: Listener)
+}


### PR DESCRIPTION

### Added

- Add `KtInventoryPluginContext` to simplify plugin dependency injection.
    - Replaced direct `Plugin` injection with `KtInventoryPluginContext`, which packages plugin-dependent data.
    - This simplifies constructor dependencies and makes testing or future dependency swapping easier.
    - Existing `Plugin` constructors are now `@Deprecated` and delegate to `KtInventoryPluginContext(plugin)`.
      ```kotlin
      // Before
      class SimpleMenu(
          plugin: Plugin,
      ) : KtInventory(plugin, 1)
  
      // After
      class SimpleMenu(
          context: KtInventoryPluginContext,
      ) : KtInventory(context, 1) {
          constructor(plugin: Plugin) : this(KtInventoryPluginContext(plugin))
      }
      ```
